### PR TITLE
Fix update sprint

### DIFF
--- a/writeBrain/models/sprint.py
+++ b/writeBrain/models/sprint.py
@@ -7,7 +7,7 @@ class Sprint(models.Model):
 
     body = models.CharField(max_length=500000)
     started_at = models.DateTimeField(auto_now=False)
-    ended_at = models.DateTimeField(auto_now=True)
+    ended_at = models.DateTimeField(auto_now=False)
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     story = models.ForeignKey(Story, on_delete=models.CASCADE)
     mood_before = models.ForeignKey(Mood, related_name="sprint_before", on_delete=models.DO_NOTHING)

--- a/writeBrain/views/sprint.py
+++ b/writeBrain/views/sprint.py
@@ -29,6 +29,7 @@ class Sprints(ViewSet):
         sprint = Sprint.objects.create(
             body=request.data["body"],
             started_at=request.data["started_at"],
+            ended_at=request.data["ended_at"],
             mood_before=mood_before,
             mood_after=mood_after,
             story=story,

--- a/writeBrain/views/sprint.py
+++ b/writeBrain/views/sprint.py
@@ -13,10 +13,6 @@ class SprintSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Sprint
-        # url = serializers.HyperlinkedIdentityField(
-        #     view_name='sprint',
-        #     lookup_field='id'
-        # )
         fields = ("id", "body", "started_at", "ended_at", "mood_before", "mood_after", "story", "user")
         depth = 1
 


### PR DESCRIPTION
Fixed update sprint so that ended_at is no longer auto-generated from API, but instead determined on frontend right before sprint is saved. 